### PR TITLE
Resolve npm Conflict Override

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "wouter": "2.7.4"
   },
   "overrides": {
-    "babel-plugin-macros": "^3.0.1"
+    "babel-plugin-macros": "^3.1.0"
   },
   "devDependencies": {
     "@types/three": "^0.156.0",


### PR DESCRIPTION
Running npm install on npm v8.6.0 fails. 

```
npm ERR! code EOVERRIDE
npm ERR! Override for babel-plugin-macros@^3.1.0 conflicts with direct dependency

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\prath\AppData\Local\npm-cache\_logs\2023-10-23T04_59_25_852Z-debug-0.log
```

This PR resolves the conflict that causes the issue.